### PR TITLE
Add package declaration as valid module paths configuration

### DIFF
--- a/src/main/java/org/dtk/analysis/page/RecursiveWebPage.java
+++ b/src/main/java/org/dtk/analysis/page/RecursiveWebPage.java
@@ -22,6 +22,7 @@ import org.dtk.analysis.script.config.ScriptConfigParser;
 import org.dtk.analysis.script.dependency.AMDScriptParser;
 import org.dtk.analysis.script.dependency.NonAMDScriptParser;
 import org.dtk.analysis.script.dependency.ScriptDependencyParser;
+import org.dtk.analysis.script.node.ArrayLiteral;
 import org.dtk.analysis.script.node.ObjectLiteral;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -177,6 +178,10 @@ public abstract class RecursiveWebPage extends WebPage implements RecursiveModul
 			updateInternalPathsConfig((ObjectLiteral) parsedScriptConfig.get(DojoConfigAttrs.PATHS_CONFIG_FLAG));
 		}
 		
+		if (parsedScriptConfig.containsKey(DojoConfigAttrs.PACKAGES_CONFIG_FLAG)) {
+			updateInternalPathsConfig((ArrayLiteral) parsedScriptConfig.get(DojoConfigAttrs.PACKAGES_CONFIG_FLAG));
+		}		
+		
 		if (parsedScriptConfig.containsKey(DojoConfigAttrs.BASE_URL_CONFIG_FLAG)) {
 			baseUrl = (String) parsedScriptConfig.get(DojoConfigAttrs.BASE_URL_CONFIG_FLAG);
 		}
@@ -195,6 +200,27 @@ public abstract class RecursiveWebPage extends WebPage implements RecursiveModul
 				modulePaths.put(packageName, (String) packagePath);
 			}
 		}
+	}
+	/**
+	 * Update the internal loader configuration paths for packages declaration,  
+	 * contains list of object literals with "name" and "location" values. 
+	 * 
+	 * Will ignore any non-string values referenced.
+	 * 
+	 * @param packages - Module packages list
+	 */	
+	protected void updateInternalPathsConfig(ArrayLiteral packages) {
+		for(Object packageInfo: packages.getValueList()) {
+			if (packageInfo instanceof ObjectLiteral) {
+				ObjectLiteral packageInfoLit = (ObjectLiteral) packageInfo;
+				Object packagePath = packageInfoLit.getValue(DojoConfigAttrs.PACKAGES_LOCATION_CONFIG_FLAG),
+				 	packageName = packageInfoLit.getValue(DojoConfigAttrs.PACKAGES_NAME_CONFIG_FLAG);
+				
+				if (packagePath instanceof String && packageName instanceof String) {
+					modulePaths.put((String) packageName, (String) packagePath);
+				}
+			}
+		}		
 	}
 	
 	/**

--- a/src/main/java/org/dtk/analysis/script/config/DojoConfigAttrs.java
+++ b/src/main/java/org/dtk/analysis/script/config/DojoConfigAttrs.java
@@ -27,4 +27,10 @@ public final class DojoConfigAttrs {
 	static public final String PATHS_CONFIG_FLAG = "paths";
 	
 	static public final String MODULE_PATHS_CONFIG_FLAG = "modulePaths";
+	
+	static public final String PACKAGES_CONFIG_FLAG = "packages";
+	
+	static public final String PACKAGES_NAME_CONFIG_FLAG = "name";
+	
+	static public final String PACKAGES_LOCATION_CONFIG_FLAG = "location";
 }

--- a/src/test/java/org/dtk/analysis/page/RecursiveWebPageTest.java
+++ b/src/test/java/org/dtk/analysis/page/RecursiveWebPageTest.java
@@ -54,6 +54,19 @@ public class RecursiveWebPageTest {
 	}
 	
 	@Test
+	public void parsesPathsValueFromPackagesConfigAttrOnScriptTag() throws IOException {
+		MockWebPage webPage = new MockWebPage();
+		webPage.isDojoScript = true;
+		
+		Attributes attrs = new Attributes();
+		attrs.put("data-dojo-config", "'packages': [{'name': 'some', 'location': 'path'}, {'name': 'an', 'location':'other'}]");		
+		
+		Element dojoScript = new Element(Tag.valueOf("script"), "", attrs);
+		webPage.parsePreDojoScript(dojoScript);
+		assertEquals(LoaderConfigParserTest.getPrepopulatedMap("some", "path", "an", "other"), webPage.modulePaths);
+	}
+	
+	@Test
 	public void parsesPathsValueFromOldConfigAttrOnScriptTag() throws IOException {
 		MockWebPage webPage = new MockWebPage();
 		webPage.isDojoScript = true;


### PR DESCRIPTION
Encountered a bug when the analysis page was using the packages
declaration to point at JS source files. We weren't previously
picking up this value correctly.

Adding code and unit tests.
