### PR TITLE
Fix issue #7 for corrupted theme files.

### DIFF
--- a/src/main/webapp/js/build/bdbuild/buildControlDefault.js
+++ b/src/main/webapp/js/build/bdbuild/buildControlDefault.js
@@ -192,7 +192,7 @@ define(["./buildControlBase"], function(bc) {
                     }
                     return false;
                 },
-                ["read", "write"]
+                ["copy"]
             ],
             
             [


### PR DESCRIPTION
Moving build control phase from "read, write" to just "copy" stopped
files PNG files being transitionally converted to UTF-8, therefore
breaking. Phew...
