### PR TITLE
Fix analysis issue parsing built layer files

### DIFF
--- a/src/main/java/org/dtk/analysis/script/dependency/AMDScriptParser.java
+++ b/src/main/java/org/dtk/analysis/script/dependency/AMDScriptParser.java
@@ -3,6 +3,7 @@ package org.dtk.analysis.script.dependency;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.mozilla.javascript.EvaluatorException;
 import org.mozilla.javascript.Node;
 import org.mozilla.javascript.Token;
 
@@ -42,6 +43,18 @@ public class AMDScriptParser extends BaseScriptDependencyParser {
 	public AMDScriptParser(String scriptSoure) {
 		super(scriptSoure);
 	}
+	
+	/**
+	 * Ignore script sources that are already built layers, 
+	 * we just want to include those rather than descend into 
+	 * the source, there be dragons.....
+	 */
+	@Override
+	protected void parse() throws EvaluatorException {
+		if (!isScriptSourceBuiltLayer()) {
+			super.parse();
+		}						
+	}	
 
 	/**
 	 * AST Node is an AMD API call that may contain module 
@@ -159,5 +172,15 @@ public class AMDScriptParser extends BaseScriptDependencyParser {
 	 */
 	protected boolean isAmdDefineCall(Node node) {		
 		return AMD_DEFINE_METHOD.equals(getFunctionName(node));
+	}
+	
+	/**
+	 * Detect whether script source contain a built layer,
+	 * indicated by custom comment at the beginning of the file.
+	 *  
+	 * @return Script is a build layer
+	 */
+	protected boolean isScriptSourceBuiltLayer() {
+		return (this.scriptSource.indexOf("//>>built") > -1);
 	}
 }

--- a/src/test/java/org/dtk/analysis/script/dependency/AMDScriptParserTest.java
+++ b/src/test/java/org/dtk/analysis/script/dependency/AMDScriptParserTest.java
@@ -75,6 +75,12 @@ public class AMDScriptParserTest {
 	}	
 	
 	@Test 
+	public void returnsEmptyListWithBuiltLayerFileDetected() {		
+		assertEquals(Arrays.asList(), getScriptDeps("//>>built\ndefine(['some/module/id'], function () {});"));
+		assertEquals(Arrays.asList(), getScriptDeps("/** some copyright */\n//>>built\ndefine(['some/module/id'], function () {});"));
+	}	
+	
+	@Test 
 	public void detectRequireCallWithSingleStringArgument() {
 		assertEquals(Arrays.asList("some/module/id"), getScriptDeps("var module = require('some/module/id');"));
 	}


### PR DESCRIPTION
Add a simple no-op for these files, we can't handle the internal
dependency logic for all these files.
